### PR TITLE
Fix PHP8 warning if no $rest provided

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -58,11 +58,13 @@ class syntax_plugin_cssperpage extends DokuWiki_Syntax_Plugin {
             switch ($state) {          
               case DOKU_LEXER_SPECIAL :
              
-               list($class,$rest) = explode(';',$match);
-                if($rest) {                    
+                $tokens = explode(';',$match);
+                $class = $tokens[0];
+                $rest = isset($tokens[1]) ? $tokens[1] : '';
+                if($rest) {
                     $match = 'openDIV';                  
                 }
-                 else {
+                else {
                      $class ='opencss';                  
                 }       
                 if($match == 'openDIV') {                  


### PR DESCRIPTION
This solves the `E_WARNING: Undefined array key 1` warning which shows up on PHP8 if `$match` doesn't include `$rest`